### PR TITLE
fix(dependencies): untied service proxy bundle from doctrine bundles

### DIFF
--- a/Tests/ContainerTestUtil.php
+++ b/Tests/ContainerTestUtil.php
@@ -2,10 +2,6 @@
 
 namespace OpenClassrooms\Bundle\ServiceProxyBundle\Tests;
 
-use Doctrine\Bundle\DoctrineCacheBundle\DependencyInjection\DoctrineCacheExtension;
-use Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle;
-use OpenClassrooms\Bundle\DoctrineCacheExtensionBundle\DependencyInjection\OpenClassroomsDoctrineCacheExtensionExtension;
-use OpenClassrooms\Bundle\DoctrineCacheExtensionBundle\OpenClassroomsDoctrineCacheExtensionBundle;
 use OpenClassrooms\Bundle\ServiceProxyBundle\OpenClassroomsServiceProxyBundle;
 use OpenClassrooms\Bundle\ServiceProxyBundle\Tests\Fixtures\Services\CacheClassStub;
 use OpenClassrooms\ServiceProxy\ServiceProxyCacheInterface;
@@ -48,29 +44,9 @@ trait ContainerTestUtil
 
         $this->container->setParameter('kernel.cache_dir', self::$kernelCacheDir);
         $this->container->setParameter('kernel.environment', 'test');
-        $this->initDoctrineCacheBundle();
-        $this->initDoctrineCacheExtensionBundle();
         $this->initServiceProxyBundle();
         $this->initServiceLoader();
         $this->initConfigLoader();
-    }
-
-    private function initDoctrineCacheBundle()
-    {
-        $doctrineCacheExtension = new DoctrineCacheExtension();
-        $this->container->registerExtension($doctrineCacheExtension);
-        $this->container->loadFromExtension('doctrine_cache');
-        $bundle = new DoctrineCacheBundle();
-        $bundle->build($this->container);
-    }
-
-    private function initDoctrineCacheExtensionBundle()
-    {
-        $doctrineCacheExtensionExtension = new OpenClassroomsDoctrineCacheExtensionExtension();
-        $this->container->registerExtension($doctrineCacheExtensionExtension);
-        $this->container->loadFromExtension('doctrine_cache_extension');
-        $bundle = new OpenClassroomsDoctrineCacheExtensionBundle();
-        $bundle->build($this->container);
     }
 
     private function initServiceProxyBundle()

--- a/Tests/DependencyInjection/CacheOpenClassroomsServiceProxyExtensionTest.php
+++ b/Tests/DependencyInjection/CacheOpenClassroomsServiceProxyExtensionTest.php
@@ -57,12 +57,12 @@ class CacheOpenClassroomsServiceProxyExtensionTest extends TestCase
         $this->container->compile();
 
         /** @var CacheProviderDecorator $specificCache */
-        $specificCache = $this->container->get('doctrine_cache.providers.specific_array_cache');
+        $specificCache = $this->container->get('openclassrooms.service_proxy.tests.cache.specific');
         $specificCache->save('test', 'data');
 
         /** @var ServiceProxyInterface|ServiceProxyCacheInterface $cacheService */
         $cacheService = $this->container->get(
-            'openclassrooms.service_proxy.tests.configuration_sepecific_cache_class_stub'
+            'openclassrooms.service_proxy.tests.configuration_specific_cache_class_stub'
         );
 
         $this->assertServiceProxy($cacheService);

--- a/Tests/Fixtures/Resources/config/cache_configuration.yml
+++ b/Tests/Fixtures/Resources/config/cache_configuration.yml
@@ -1,9 +1,3 @@
-doctrine_cache:
-    providers:
-        default_array_cache:
-            type: array
-        specific_array_cache:
-            type: array
 openclassrooms_service_proxy:
-    default_cache: doctrine_cache.providers.default_array_cache
+    default_cache: "openclassrooms.service_proxy.tests.cache.default"
     production_environments: [test]

--- a/Tests/Fixtures/Resources/config/cache_configuration_services.xml
+++ b/Tests/Fixtures/Resources/config/cache_configuration_services.xml
@@ -1,10 +1,21 @@
 <container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://symfony.com/schema/dic/services" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
+        <service id="openclassrooms.service_proxy.tests.cache.default" class="OpenClassrooms\DoctrineCacheExtension\CacheProviderDecorator" public="true">
+            <argument type="service">
+                <service class="Doctrine\Common\Cache\ArrayCache" />
+            </argument>
+        </service>
+        <service id="openclassrooms.service_proxy.tests.cache.specific" class="OpenClassrooms\DoctrineCacheExtension\CacheProviderDecorator" public="true">
+            <argument type="service">
+                <service class="Doctrine\Common\Cache\ArrayCache" />
+            </argument>
+        </service>
+
         <service id="openclassrooms.service_proxy.tests.configuration_cache_class_stub" class="OpenClassrooms\Bundle\ServiceProxyBundle\Tests\Fixtures\Services\CacheClassStub">
             <tag name="openclassrooms.service_proxy"/>
         </service>
-        <service id="openclassrooms.service_proxy.tests.configuration_sepecific_cache_class_stub" class="OpenClassrooms\Bundle\ServiceProxyBundle\Tests\Fixtures\Services\CacheClassStub" public="true">
-            <tag name="openclassrooms.service_proxy" cache="doctrine_cache.providers.specific_array_cache"/>
+        <service id="openclassrooms.service_proxy.tests.configuration_specific_cache_class_stub" class="OpenClassrooms\Bundle\ServiceProxyBundle\Tests\Fixtures\Services\CacheClassStub" public="true">
+            <tag name="openclassrooms.service_proxy" cache="openclassrooms.service_proxy.tests.cache.specific"/>
         </service>
     </services>
 </container>

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
     "php": ">=7.4",
     "openclassrooms/service-proxy" : "2.0.1",
     "openclassrooms/doctrine-cache-extension": "1.0.*@dev",
-    "openclassrooms/doctrine-cache-extension-bundle": "2.0.*@dev",
     "symfony/dependency-injection": "~3.4 || ~4.0",
     "symfony/config": "~3.4 || ~4.0",
     "symfony/http-kernel": "~3.4 || ~4.0",


### PR DESCRIPTION
As doctrine cache bundle is now abandoned, the new recommendations are to rely on custom implementations of doctrine cache services